### PR TITLE
Use .scss extension for sass helpers

### DIFF
--- a/vendor/assets/stylesheets/hopscotch.scss
+++ b/vendor/assets/stylesheets/hopscotch.scss
@@ -402,7 +402,7 @@ div.hopscotch-bubble.no-number .hopscotch-bubble-content {
 div.hopscotch-bubble .hopscotch-bubble-close {
     color: #000;
     background: transparent -192px -92px no-repeat;
-    background-image: url('sprite-green.png');
+    background-image: image-url('sprite-green.png');
     display: block;
     padding: 8px;
     position: absolute;
@@ -419,7 +419,7 @@ div.hopscotch-bubble .hopscotch-bubble-close.hide-all {
 }
 div.hopscotch-bubble .hopscotch-bubble-number {
     background: transparent 0 0 no-repeat;
-    background-image: url('sprite-green.png');
+    background-image: image-url('sprite-green.png');
     color: #fff;
     display: block;
     float: left;


### PR DESCRIPTION
To use the image-url sass helper, the file needs to have a .scss extension.